### PR TITLE
Add `yarn build` step to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ JS SDK for Lido Finance projects.
 
 ## Install
 
-```
-yarn && yarn postinstall
-```
+1. `yarn && yarn postinstall`
+2. `yarn build`
 
 ## Usage
 


### PR DESCRIPTION
We have TS errors on importing packages if the project wasn't built at least once.