### PR TITLE
Add Coin98 connector

### DIFF
--- a/packages/web3-react/src/constants/connectors.ts
+++ b/packages/web3-react/src/constants/connectors.ts
@@ -8,6 +8,7 @@ export enum PROVIDER_NAMES {
   INJECTED = 'Injected',
   LEDGER_HQ_LIVE = 'Ledger Live',
   LEDGER = 'Ledger',
+  COIN98 = 'Coin98',
 }
 
 export enum CONNECTOR_NAMES {
@@ -17,4 +18,5 @@ export enum CONNECTOR_NAMES {
   INJECTED = 'injected',
   LEDGER_HQ_LIVE = 'ledgerlive',
   LEDGER = 'ledger',
+  COIN98 = 'coin98',
 }

--- a/packages/web3-react/src/helpers/injected.ts
+++ b/packages/web3-react/src/helpers/injected.ts
@@ -2,10 +2,12 @@ import { isMobileOrTablet } from './ua';
 
 declare global {
   interface Window {
+    coin98?: boolean;
     ethereum?: {
       isMetaMask?: boolean;
       isTrust?: boolean;
       isImToken?: boolean;
+      isCoin98?: boolean;
     };
   }
 }
@@ -21,6 +23,14 @@ export const hasInjected = (): boolean => {
 export const isMetamaskProvider = (): boolean => {
   try {
     return !!window.ethereum?.isMetaMask;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const isCoin98Provider = (): boolean => {
+  try {
+    return !!window.coin98 || !!window.ethereum?.isCoin98;
   } catch (error) {
     return false;
   }

--- a/packages/web3-react/src/helpers/ua.ts
+++ b/packages/web3-react/src/helpers/ua.ts
@@ -12,3 +12,5 @@ export const isAndroid = os.name === 'Android';
 export const isMobile = device.type === 'mobile';
 export const isTablet = device.type === 'tablet';
 export const isMobileOrTablet = isMobile || isTablet;
+
+export const isFirefox = browser.name === 'Firefox';

--- a/packages/web3-react/src/hooks/index.ts
+++ b/packages/web3-react/src/hooks/index.ts
@@ -4,6 +4,7 @@ export * from './useConnectorImToken';
 export * from './useConnectorInfo';
 export * from './useConnectorLedger';
 export * from './useConnectorMetamask';
+export * from './useConnectorCoin98';
 export * from './useConnectors';
 export * from './useConnectorStorage';
 export * from './useConnectorTrust';

--- a/packages/web3-react/src/hooks/useConnectorCoin98.ts
+++ b/packages/web3-react/src/hooks/useConnectorCoin98.ts
@@ -1,5 +1,4 @@
 import invariant from 'tiny-invariant';
-import warning from 'tiny-warning';
 import { useCallback } from 'react';
 import { openWindow } from '@lido-sdk/helpers';
 import { useConnectors } from './useConnectors';
@@ -17,20 +16,16 @@ export const useConnectorCoin98 = (): Connector => {
   const { disconnect } = useForceDisconnect();
 
   const openInWallet = useCallback(() => {
-    try {
-      if (isAndroid) {
-        openWindow('https://android.coin98.app');
-      } else if (isIOS) {
-        openWindow('https://ios.coin98.app');
-      } else if (isFirefox) {
-        openWindow(
-          'https://docs.coin98.com/products/coin98-wallet/extension/beginners-guide/install-extension-firefox',
-        );
-      } else {
-        openWindow('https://chrome.coin98.com');
-      }
-    } catch (error) {
-      warning(false, 'Failed to open the link');
+    if (isAndroid) {
+      openWindow('https://android.coin98.app');
+    } else if (isIOS) {
+      openWindow('https://ios.coin98.app');
+    } else if (isFirefox) {
+      openWindow(
+        'https://docs.coin98.com/products/coin98-wallet/extension/beginners-guide/install-extension-firefox',
+      );
+    } else {
+      openWindow('https://chrome.coin98.com');
     }
   }, []);
 

--- a/packages/web3-react/src/hooks/useConnectorCoin98.ts
+++ b/packages/web3-react/src/hooks/useConnectorCoin98.ts
@@ -1,0 +1,49 @@
+import invariant from 'tiny-invariant';
+import warning from 'tiny-warning';
+import { useCallback } from 'react';
+import { openWindow } from '@lido-sdk/helpers';
+import { useConnectors } from './useConnectors';
+import { useWeb3 } from './useWeb3';
+import { hasInjected, isAndroid, isIOS, isFirefox } from '../helpers';
+import { useForceDisconnect } from './useDisconnect';
+
+type Connector = {
+  connect: () => Promise<void>;
+};
+
+export const useConnectorCoin98 = (): Connector => {
+  const { injected } = useConnectors();
+  const { activate } = useWeb3();
+  const { disconnect } = useForceDisconnect();
+
+  const openInWallet = useCallback(() => {
+    try {
+      if (isAndroid) {
+        openWindow('https://android.coin98.app');
+      } else if (isIOS) {
+        openWindow('https://ios.coin98.app');
+      } else if (isFirefox) {
+        openWindow(
+          'https://docs.coin98.com/products/coin98-wallet/extension/beginners-guide/install-extension-firefox',
+        );
+      } else {
+        openWindow('https://chrome.coin98.com');
+      }
+    } catch (error) {
+      warning(false, 'Failed to open the link');
+    }
+  }, []);
+
+  const connect = useCallback(async () => {
+    invariant(injected, 'Connector is required');
+
+    if (hasInjected()) {
+      await disconnect();
+      activate(injected);
+    } else {
+      openInWallet();
+    }
+  }, [activate, disconnect, openInWallet, injected]);
+
+  return { connect };
+};

--- a/packages/web3-react/src/hooks/useConnectorInfo.ts
+++ b/packages/web3-react/src/hooks/useConnectorInfo.ts
@@ -11,6 +11,7 @@ import {
   isDappBrowserProvider,
   isImTokenProvider,
   isMetamaskProvider,
+  isCoin98Provider,
   isTrustProvider,
 } from '../helpers';
 
@@ -20,6 +21,7 @@ type ConnectorInfo = {
   isImToken: boolean;
   isTrust: boolean;
   isMetamask: boolean;
+  isCoin98: boolean;
   isGnosis: boolean;
   isLedger: boolean;
   isLedgerLive: boolean;
@@ -41,6 +43,7 @@ export const useConnectorInfo = (): ConnectorInfo => {
   const isInjected = active && connector instanceof InjectedConnector;
   const isDappBrowser = isInjected && isDappBrowserProvider();
   const isMetamask = isInjected && isMetamaskProvider();
+  const isCoin98 = isInjected && isCoin98Provider();
   const isImToken = isInjected && isImTokenProvider();
   const isTrust = isInjected && isTrustProvider();
 
@@ -53,6 +56,7 @@ export const useConnectorInfo = (): ConnectorInfo => {
 
     if (isImToken) return PROVIDER_NAMES.IM_TOKEN;
     if (isMetamask) return PROVIDER_NAMES.METAMASK;
+    if (isCoin98) return PROVIDER_NAMES.COIN98;
     if (isTrust) return PROVIDER_NAMES.TRUST;
 
     if (isInjected) return PROVIDER_NAMES.INJECTED;
@@ -84,6 +88,7 @@ export const useConnectorInfo = (): ConnectorInfo => {
 
     isImToken,
     isMetamask,
+    isCoin98,
     isTrust,
 
     isDappBrowser,

--- a/packages/web3-react/src/index.ts
+++ b/packages/web3-react/src/index.ts
@@ -1,3 +1,4 @@
 export * from './constants';
 export * from './context';
 export * from './hooks';
+export * as helpers from './helpers';

--- a/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
@@ -1,9 +1,7 @@
 jest.mock('@lido-sdk/helpers');
-jest.mock('tiny-warning');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
-import warning from 'tiny-warning';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { openWindow } from '@lido-sdk/helpers';
 import { useConnectorCoin98 } from '../../src/hooks/useConnectorCoin98';
@@ -15,14 +13,12 @@ const mockUseConnectors = useConnectors as jest.MockedFunction<
   typeof useConnectors
 >;
 const mockOpenWindow = openWindow as jest.MockedFunction<typeof openWindow>;
-const mockWarning = warning as jest.MockedFunction<typeof warning>;
 
 beforeEach(() => {
   delete window.ethereum;
   mockUseWeb3.mockReturnValue({} as any);
   mockUseConnectors.mockReturnValue({ injected: {} } as any);
   mockOpenWindow.mockReset();
-  mockWarning.mockReset();
 });
 
 describe('useConnectorCoin98', () => {

--- a/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
@@ -1,0 +1,52 @@
+jest.mock('@lido-sdk/helpers');
+jest.mock('tiny-warning');
+jest.mock('../../src/hooks/useWeb3');
+jest.mock('../../src/hooks/useConnectors');
+
+import warning from 'tiny-warning';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { openWindow } from '@lido-sdk/helpers';
+import { useConnectorCoin98 } from '../../src/hooks/useConnectorCoin98';
+import { useWeb3 } from '../../src/hooks/useWeb3';
+import { useConnectors } from '../../src/hooks/useConnectors';
+
+const mockUseWeb3 = useWeb3 as jest.MockedFunction<typeof useWeb3>;
+const mockUseConnectors = useConnectors as jest.MockedFunction<
+  typeof useConnectors
+>;
+const mockOpenWindow = openWindow as jest.MockedFunction<typeof openWindow>;
+const mockWarning = warning as jest.MockedFunction<typeof warning>;
+
+beforeEach(() => {
+  delete window.ethereum;
+  mockUseWeb3.mockReturnValue({} as any);
+  mockUseConnectors.mockReturnValue({ injected: {} } as any);
+  mockOpenWindow.mockReset();
+  mockWarning.mockReset();
+});
+
+describe('useConnectorCoin98', () => {
+  test('should connect if ethereum if presented', async () => {
+    const mockActivate = jest.fn(async () => true);
+    const injected = {};
+
+    window.ethereum = {};
+    mockUseWeb3.mockReturnValue({ activate: mockActivate } as any);
+    mockUseConnectors.mockReturnValue({ injected } as any);
+
+    const { result } = renderHook(() => useConnectorCoin98());
+    const { connect } = result.current;
+
+    await act(() => connect());
+    expect(mockActivate).toHaveBeenCalledWith(injected);
+    expect(mockActivate).toHaveBeenCalledTimes(1);
+  });
+
+  test('should open window if ethereum is not presented', async () => {
+    const { result } = renderHook(() => useConnectorCoin98());
+    const { connect } = result.current;
+
+    await act(() => connect());
+    expect(mockOpenWindow).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Coin98 is added to the old Stake Widget.
We need to add it to the Frontend Template and to the new version of Stake Widget.
In order to do this, we need to add it to the SDK first.

Tested using Lido Frontend Template, the wallet can be successfully connected to the widget.