### PR TITLE
fix(coin98): check for the extension before activation

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorCoin98.ts
+++ b/packages/web3-react/src/hooks/useConnectorCoin98.ts
@@ -3,7 +3,13 @@ import { useCallback } from 'react';
 import { openWindow } from '@lido-sdk/helpers';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isAndroid, isIOS, isFirefox } from '../helpers';
+import {
+  hasInjected,
+  isAndroid,
+  isIOS,
+  isFirefox,
+  isCoin98Provider,
+} from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 
 type Connector = {
@@ -36,7 +42,7 @@ export const useConnectorCoin98 = (): Connector => {
   const connect = useCallback(async () => {
     invariant(injected, 'Connector is required');
 
-    if (hasInjected()) {
+    if (hasInjected() && isCoin98Provider()) {
       await disconnect();
       activate(injected);
     } else {

--- a/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
@@ -22,11 +22,12 @@ beforeEach(() => {
 });
 
 describe('useConnectorCoin98', () => {
-  test('should connect if ethereum if presented', async () => {
+  test('should connect if ethereum and coin98 are presented', async () => {
     const mockActivate = jest.fn(async () => true);
     const injected = {};
 
     window.ethereum = {};
+    window.coin98 = true;
     mockUseWeb3.mockReturnValue({ activate: mockActivate } as any);
     mockUseConnectors.mockReturnValue({ injected } as any);
 
@@ -41,6 +42,20 @@ describe('useConnectorCoin98', () => {
   test('should open window if ethereum is not presented', async () => {
     const { result } = renderHook(() => useConnectorCoin98());
     const { connect } = result.current;
+
+    window.ethereum = undefined;
+    window.coin98 = true;
+
+    await act(() => connect());
+    expect(mockOpenWindow).toHaveBeenCalledTimes(1);
+  });
+
+  test('should open window if coin98 is not presented', async () => {
+    const { result } = renderHook(() => useConnectorCoin98());
+    const { connect } = result.current;
+
+    window.ethereum = {};
+    window.coin98 = undefined;
 
     await act(() => connect());
     expect(mockOpenWindow).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This PR fixes the following case.
A user has Metamask extension and doesn't have Coin98 extension installed.
The user selects the Coin98 wallet in the connection modal.
**Actual result:** The Metamask extension will open.
**Expected result:** We should redirect the user to the Coin98 extension's page. We have such behavior on the old staking widget.