### PR TITLE
fix(web3): incorrect url encoding for metamask deeplinking

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorMetamask.ts
+++ b/packages/web3-react/src/hooks/useConnectorMetamask.ts
@@ -26,9 +26,7 @@ export const useConnectorMetamask = (): Connector => {
   const openInWallet = useCallback(() => {
     try {
       const { host, pathname, search } = window.location;
-      const pageUrlWithoutProtocol = encodeURIComponent(
-        host + pathname + search,
-      );
+      const pageUrlWithoutProtocol = encodeURI(host + pathname + search);
       openWindow(`${METAMASK_URL}${pageUrlWithoutProtocol}`);
     } catch (error) {
       warning(false, 'Failed to open the link');


### PR DESCRIPTION
This PR includes a fix for deeplinking into metamask mobile. `encodeURIComponent` encodes `/` character to `%2F`, which leads to metamask dapp browser not being able to parse url. Using `encodeURI` solves this problem because it does not encode forward slashes. E.g.
![image](https://user-images.githubusercontent.com/39704351/138675537-4649a01f-46c0-4331-bae2-282ee934621e.png)