### PR TITLE
Fix: use the new extension link for coin98 on firefox

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorCoin98.ts
+++ b/packages/web3-react/src/hooks/useConnectorCoin98.ts
@@ -20,7 +20,7 @@ const androidAppLink = 'https://android.coin98.app';
 const iosAppLink = 'https://ios.coin98.app';
 const chromeAppLink = 'https://chrome.coin98.com';
 const installExtensionFirefoxDocs =
-  'https://docs.coin98.com/products/coin98-wallet/extension/beginners-guide/install-extension-firefox';
+  'https://docs.coin98.com/products/coin98-wallet/extension/beginners-guide/install-extension#on-firefox';
 
 export const useConnectorCoin98 = (): Connector => {
   const { injected } = useConnectors();


### PR DESCRIPTION
The address of the page from the Coin98 documentation for Firefox users was changed recently on the Coin98 side.
This PR replaces the old link with the new one.