### PR TITLE
Replace legacy mathwallet appstore links with links to mathwallet5

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorMathWallet.ts
+++ b/packages/web3-react/src/hooks/useConnectorMathWallet.ts
@@ -18,9 +18,8 @@ type Connector = {
 };
 
 const androidAppLink =
-  'https://play.google.com/store/apps/details?id=com.medishares.android';
-const iosAppLink =
-  'https://apps.apple.com/ru/app/math-wallet-blockchain-wallet/id1383637331';
+  'https://play.google.com/store/apps/details?id=com.mathwallet.android';
+const iosAppLink = 'https://apps.apple.com/ru/app/mathwallet5/id1582612388';
 const chromeAppLink =
   'https://chrome.google.com/webstore/detail/math-wallet/afbcbjpbpfadlkmhmclhkeeodmamcflc';
 const edgeAppLink =


### PR DESCRIPTION
Mathwallet suddenly released another mobile app (MathWallet5) and declared the old app as legacy and deprecated.
So, the PR changes the links to the app.