### PR TITLE
Fix(web3-react): reorder wallets in providerName function

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorInfo.ts
+++ b/packages/web3-react/src/hooks/useConnectorInfo.ts
@@ -55,13 +55,16 @@ export const useConnectorInfo = (): ConnectorInfo => {
     if (isLedger) return PROVIDER_NAMES.LEDGER;
     if (isLedgerLive) return PROVIDER_NAMES.LEDGER_HQ_LIVE;
     if (isWalletConnect) return PROVIDER_NAMES.WALLET_CONNECT;
-
     if (isImToken) return PROVIDER_NAMES.IM_TOKEN;
-    if (isCoin98) return PROVIDER_NAMES.COIN98;
-    if (isMathWallet) return PROVIDER_NAMES.MATH_WALLET;
     if (isTrust) return PROVIDER_NAMES.TRUST;
-    if (isMetamask) return PROVIDER_NAMES.METAMASK;
 
+    // Wallets which use "Injected" aka EIP-1193 API.
+    // The order of wallets here must correspond to the order of disabling
+    // the wallet connection buttons. Most "aggressive" wallet,
+    // which disables other wallets, goes first here.
+    if (isMathWallet) return PROVIDER_NAMES.MATH_WALLET;
+    if (isCoin98) return PROVIDER_NAMES.COIN98;
+    if (isMetamask) return PROVIDER_NAMES.METAMASK;
     if (isInjected) return PROVIDER_NAMES.INJECTED;
 
     return undefined;


### PR DESCRIPTION
This PR fixes the following issue:
1. Mathwallet and Coin98 extensions are installed and turned on.
2. A user connects a MathWallet wallet.
3. A user goes to the Account modal. There is a notification: "Connected with Coin98".
It happens because the `providerName` detection is primitive.

Introducing this quick fix for now.