### PR TITLE
Update how we detect that the Coinbase Wallet is connected

### DIFF
--- a/packages/web3-react/src/helpers/index.ts
+++ b/packages/web3-react/src/helpers/index.ts
@@ -1,4 +1,4 @@
-export * from './injected';
+export * from './providerDetectors';
 export * from './ua';
 export { default as isUrl } from './isUrl';
 export { default as interceptLedgerError } from './interceptLedgerError';

--- a/packages/web3-react/src/helpers/providerDetectors.ts
+++ b/packages/web3-react/src/helpers/providerDetectors.ts
@@ -9,6 +9,7 @@ declare global {
       isImToken?: boolean;
       isCoin98?: boolean;
       isMathWallet?: boolean;
+      isCoinbaseWallet?: boolean;
     };
   }
 }
@@ -63,4 +64,12 @@ export const isTrustProvider = (): boolean => {
 
 export const isDappBrowserProvider = (): boolean => {
   return isMobileOrTablet && hasInjected();
+};
+
+export const isCoinbaseProvider = (): boolean => {
+  try {
+    return !!window.ethereum?.isCoinbaseWallet;
+  } catch (error) {
+    return false;
+  }
 };

--- a/packages/web3-react/src/hooks/useConnectorInfo.ts
+++ b/packages/web3-react/src/hooks/useConnectorInfo.ts
@@ -1,7 +1,6 @@
 import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
-import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 import { LedgerHQFrameConnector } from 'web3-ledgerhq-frame-connector';
 import { LedgerHQConnector } from 'web3-ledgerhq-connector';
 import { useWeb3 } from './useWeb3';
@@ -14,6 +13,7 @@ import {
   isCoin98Provider,
   isTrustProvider,
   isMathWalletProvider,
+  isCoinbaseProvider,
 } from '../helpers';
 
 type ConnectorInfo = {
@@ -37,7 +37,7 @@ export const useConnectorInfo = (): ConnectorInfo => {
 
   const isGnosis = active && connector instanceof SafeAppConnector;
   const isWalletConnect = active && connector instanceof WalletConnectConnector;
-  const isCoinbase = active && connector instanceof WalletLinkConnector;
+  const isCoinbase = active && isCoinbaseProvider();
   const isLedgerLive = active && connector instanceof LedgerHQFrameConnector;
   const isLedger = connector instanceof LedgerHQConnector;
 
@@ -50,7 +50,6 @@ export const useConnectorInfo = (): ConnectorInfo => {
   const isTrust = isInjected && isTrustProvider();
 
   const providerName = (() => {
-    if (isCoinbase) return PROVIDER_NAMES.COINBASE;
     if (isGnosis) return PROVIDER_NAMES.GNOSIS;
     if (isLedger) return PROVIDER_NAMES.LEDGER;
     if (isLedgerLive) return PROVIDER_NAMES.LEDGER_HQ_LIVE;
@@ -58,10 +57,11 @@ export const useConnectorInfo = (): ConnectorInfo => {
     if (isImToken) return PROVIDER_NAMES.IM_TOKEN;
     if (isTrust) return PROVIDER_NAMES.TRUST;
 
-    // Wallets which use "Injected" aka EIP-1193 API.
+    // Wallets which has conflicts with each other.
     // The order of wallets here must correspond to the order of disabling
     // the wallet connection buttons. Most "aggressive" wallet,
     // which disables other wallets, goes first here.
+    if (isCoinbase) return PROVIDER_NAMES.COINBASE;
     if (isMathWallet) return PROVIDER_NAMES.MATH_WALLET;
     if (isCoin98) return PROVIDER_NAMES.COIN98;
     if (isMetamask) return PROVIDER_NAMES.METAMASK;

--- a/packages/web3-react/test/helpers/injected.test.ts
+++ b/packages/web3-react/test/helpers/injected.test.ts
@@ -6,7 +6,7 @@ import {
   isMathWalletProvider,
   isTrustProvider,
   isDappBrowserProvider,
-} from '../../src/helpers/injected';
+} from '../../src/helpers/providerDetectors';
 
 const windowSpy = jest.spyOn(global, 'window', 'get');
 const mockIsMobileOrTablet = jest.fn();

--- a/packages/web3-react/test/hooks/useAutoConnect.test.ts
+++ b/packages/web3-react/test/hooks/useAutoConnect.test.ts
@@ -3,7 +3,7 @@ jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectorStorage');
 jest.mock('../../src/hooks/useConnectorInfo');
 jest.mock('../../src/hooks/useDisconnect');
-jest.mock('../../src/helpers/injected');
+jest.mock('../../src/helpers/providerDetectors');
 
 import warning from 'tiny-warning';
 import { renderHook, act } from '@testing-library/react-hooks';
@@ -18,7 +18,7 @@ import {
   useDeleteConnectorFromLS,
   useWatchConnectorInLS,
 } from '../../src/hooks/useAutoConnect';
-import { isDappBrowserProvider } from '../../src/helpers/injected';
+import { isDappBrowserProvider } from '../../src/helpers/providerDetectors';
 
 const mockUseWeb3 = useWeb3 as jest.MockedFunction<typeof useWeb3>;
 const mockUseConnectorStorage = useConnectorStorage as jest.MockedFunction<

--- a/packages/web3-react/test/hooks/useConnectorInfo.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorInfo.test.ts
@@ -65,6 +65,8 @@ describe('useConnectorInfo', () => {
 
   test('should detect coinbase', async () => {
     mockConnector(WalletLinkConnector);
+    window.ethereum = { isCoinbaseWallet: true };
+
     const { result } = renderHook(() => useConnectorInfo());
     const { connectorName, providerName, isCoinbase, ...rest } = result.current;
 


### PR DESCRIPTION
Coinbase had a major update of their browser extension.
Unfortunately, there is no developer documentation for the Coinbase Wallet. But I found that the browser extension and the mobile app use the` window.ethereum.isCoinbaseWallet` property to indicate that the wallet is installed. Previously we just detected that WalletLink protocol is used, and if it is true, then Coinbase Wallet is used. But WalletLink is an open protocol, and any wallet other than Coinbase can use it. So I think it is better to detect Coinbase Wallet more explicitly.