### PR TITLE
Restore WalletLink provider detection

### DIFF
--- a/packages/web3-react/src/constants/connectors.ts
+++ b/packages/web3-react/src/constants/connectors.ts
@@ -4,6 +4,7 @@ export enum PROVIDER_NAMES {
   IM_TOKEN = 'imToken',
   TRUST = 'Trust',
   WALLET_CONNECT = 'WalletConnect',
+  WALLET_LINK = 'WalletLink',
   COINBASE = 'Coinbase',
   INJECTED = 'Injected',
   LEDGER_HQ_LIVE = 'Ledger Live',
@@ -15,6 +16,7 @@ export enum PROVIDER_NAMES {
 export enum CONNECTOR_NAMES {
   GNOSIS = 'gnosis',
   WALLET_CONNECT = 'walletconnect',
+  WALLET_LINK = 'walletlink',
   COINBASE = 'coinbase',
   INJECTED = 'injected',
   LEDGER_HQ_LIVE = 'ledgerlive',

--- a/packages/web3-react/src/context/connectors.tsx
+++ b/packages/web3-react/src/context/connectors.tsx
@@ -21,6 +21,7 @@ export interface ConnectorsContextProps {
 export type ConnectorsContextValue = {
   injected: InjectedConnector;
   walletconnect: WalletConnectConnector;
+  walletlink: WalletLinkConnector;
   coinbase: WalletLinkConnector;
   ledgerlive: LedgerHQFrameConnector;
   ledger: LedgerHQConnector;
@@ -86,6 +87,14 @@ const ProviderConnectors: FC<ConnectorsContextProps> = (props) => {
       }),
 
       [CONNECTOR_NAMES.COINBASE]: new WalletLinkConnector({
+        // only mainnet
+        url: rpc[CHAINS.Mainnet],
+        supportedChainIds,
+        appName,
+        appLogoUrl,
+      }),
+
+      [CONNECTOR_NAMES.WALLET_LINK]: new WalletLinkConnector({
         // only mainnet
         url: rpc[CHAINS.Mainnet],
         supportedChainIds,

--- a/packages/web3-react/src/hooks/useConnectorInfo.ts
+++ b/packages/web3-react/src/hooks/useConnectorInfo.ts
@@ -1,6 +1,7 @@
 import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
+import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 import { LedgerHQFrameConnector } from 'web3-ledgerhq-frame-connector';
 import { LedgerHQConnector } from 'web3-ledgerhq-connector';
 import { useWeb3 } from './useWeb3';
@@ -37,9 +38,14 @@ export const useConnectorInfo = (): ConnectorInfo => {
 
   const isGnosis = active && connector instanceof SafeAppConnector;
   const isWalletConnect = active && connector instanceof WalletConnectConnector;
-  const isCoinbase = active && isCoinbaseProvider();
   const isLedgerLive = active && connector instanceof LedgerHQFrameConnector;
   const isLedger = connector instanceof LedgerHQConnector;
+
+  // WalletLink is used by Coinbase, but it can be used by other wallets too.
+  const isWalletLink = active && connector instanceof WalletLinkConnector;
+
+  // This detection doesn't work for the connection via QR code scanning.
+  const isCoinbase = active && isCoinbaseProvider();
 
   const isInjected = active && connector instanceof InjectedConnector;
   const isDappBrowser = isInjected && isDappBrowserProvider();
@@ -65,6 +71,10 @@ export const useConnectorInfo = (): ConnectorInfo => {
     if (isMathWallet) return PROVIDER_NAMES.MATH_WALLET;
     if (isCoin98) return PROVIDER_NAMES.COIN98;
     if (isMetamask) return PROVIDER_NAMES.METAMASK;
+
+    // General providers which doesn't specify what exact wallet is being used.
+    // Works as a fallback.
+    if (isWalletLink) return PROVIDER_NAMES.WALLET_LINK;
     if (isInjected) return PROVIDER_NAMES.INJECTED;
 
     return undefined;
@@ -77,6 +87,9 @@ export const useConnectorInfo = (): ConnectorInfo => {
     if (isLedgerLive) return CONNECTOR_NAMES.LEDGER_HQ_LIVE;
     if (isWalletConnect) return CONNECTOR_NAMES.WALLET_CONNECT;
 
+    // General providers which doesn't specify what exact wallet is being used.
+    // Works as a fallback.
+    if (isWalletLink) return CONNECTOR_NAMES.WALLET_LINK;
     if (isInjected) return CONNECTOR_NAMES.INJECTED;
 
     return undefined;


### PR DESCRIPTION
Previously I removed the WalletLink provider detection: https://github.com/lidofinance/lido-js-sdk/pull/31.
The reason was that only Coinbase uses it, and we can detect Coinbase wallet more specifically.
It created this minor issue: if a user connects Coinbase wallet via scanning a QR code from the mobile app, the Coinbase detection doesn't work. We can only detect that it is some WalletLink based wallet, so it can be used as a fallback.
This PR fixes this minor issue.