### PR TITLE
Update connectors

### DIFF
--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -43,7 +43,7 @@
     "@web3-react/walletlink-connector": "6.2.5",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3",
-    "ua-parser-js": "^0.7.28",
+    "ua-parser-js": "1.0.2",
     "web3-ledgerhq-connector": "^1.2.2",
     "web3-ledgerhq-frame-connector": "^1.0.1"
   },

--- a/packages/web3-react/src/hooks/useConnectorCoin98.ts
+++ b/packages/web3-react/src/hooks/useConnectorCoin98.ts
@@ -11,9 +11,11 @@ import {
   isCoin98Provider,
 } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
+import { InjectedConnector } from '@web3-react/injected-connector';
 
 type Connector = {
   connect: () => Promise<void>;
+  connector: InjectedConnector;
 };
 
 const androidAppLink = 'https://android.coin98.app';
@@ -50,5 +52,5 @@ export const useConnectorCoin98 = (): Connector => {
     }
   }, [activate, disconnect, suggestApp, injected]);
 
-  return { connect };
+  return { connect, connector: injected };
 };

--- a/packages/web3-react/src/hooks/useConnectorCoinbase.ts
+++ b/packages/web3-react/src/hooks/useConnectorCoinbase.ts
@@ -2,9 +2,11 @@ import { useCallback } from 'react';
 import { useConnectors } from './useConnectors';
 import { useForceDisconnect } from './useDisconnect';
 import { useWeb3 } from './useWeb3';
+import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 
 type Connector = {
   connect: () => Promise<void>;
+  connector: WalletLinkConnector;
 };
 
 export const useConnectorCoinbase = (): Connector => {
@@ -17,5 +19,5 @@ export const useConnectorCoinbase = (): Connector => {
     activate(coinbase);
   }, [activate, disconnect, coinbase]);
 
-  return { connect };
+  return { connect, connector: coinbase };
 };

--- a/packages/web3-react/src/hooks/useConnectorImToken.ts
+++ b/packages/web3-react/src/hooks/useConnectorImToken.ts
@@ -4,11 +4,13 @@ import { useCallback } from 'react';
 import { openWindow } from '@lido-sdk/helpers';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isMobileOrTablet } from '../helpers';
+import { hasInjected } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
+import { InjectedConnector } from '@web3-react/injected-connector';
 
 type Connector = {
-  connect?: () => Promise<void>;
+  connect: () => Promise<void>;
+  connector: InjectedConnector;
 };
 
 const IM_TOKEN_URL = 'imtokenv2://navigate?screen=DappView&url=';
@@ -38,9 +40,8 @@ export const useConnectorImToken = (): Connector => {
     }
   }, [activate, disconnect, openInWallet, injected]);
 
-  const available = isMobileOrTablet;
-
   return {
-    connect: available ? connect : undefined,
+    connect,
+    connector: injected,
   };
 };

--- a/packages/web3-react/src/hooks/useConnectorLedger.ts
+++ b/packages/web3-react/src/hooks/useConnectorLedger.ts
@@ -1,10 +1,12 @@
 import { useCallback } from 'react';
+import { LedgerHQConnector } from 'web3-ledgerhq-connector';
 import { useConnectors } from './useConnectors';
 import { useForceDisconnect } from './useDisconnect';
 import { useWeb3 } from './useWeb3';
 
 type Connector = {
-  connect?: () => Promise<void>;
+  connect: () => Promise<void>;
+  connector: LedgerHQConnector;
 };
 
 export const useConnectorLedger = (): Connector => {
@@ -17,9 +19,8 @@ export const useConnectorLedger = (): Connector => {
     activate(ledger);
   }, [activate, disconnect, ledger]);
 
-  const available = ledger.isSupported();
-
   return {
-    connect: available ? connect : undefined,
+    connect,
+    connector: ledger,
   };
 };

--- a/packages/web3-react/src/hooks/useConnectorMathWallet.ts
+++ b/packages/web3-react/src/hooks/useConnectorMathWallet.ts
@@ -12,9 +12,11 @@ import {
   isMathWalletProvider,
 } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
+import { InjectedConnector } from '@web3-react/injected-connector';
 
 type Connector = {
   connect: () => Promise<void>;
+  connector: InjectedConnector;
 };
 
 const androidAppLink =
@@ -56,5 +58,5 @@ export const useConnectorMathWallet = (): Connector => {
     }
   }, [activate, disconnect, suggestApp, injected]);
 
-  return { connect };
+  return { connect, connector: injected };
 };

--- a/packages/web3-react/src/hooks/useConnectorMetamask.ts
+++ b/packages/web3-react/src/hooks/useConnectorMetamask.ts
@@ -6,15 +6,12 @@ import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
 import { hasInjected } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
+import { InjectedConnector } from '@web3-react/injected-connector';
 
 type Connector = {
   connect: () => Promise<void>;
+  connector: InjectedConnector;
 };
-
-/*
- * TODO: add onboarding
- * https://docs.metamask.io/guide/onboarding-library.html
- */
 
 const METAMASK_URL = 'https://metamask.app.link/dapp/';
 
@@ -44,5 +41,5 @@ export const useConnectorMetamask = (): Connector => {
     }
   }, [activate, disconnect, openInWallet, injected]);
 
-  return { connect };
+  return { connect, connector: injected };
 };

--- a/packages/web3-react/src/hooks/useConnectorTally.ts
+++ b/packages/web3-react/src/hooks/useConnectorTally.ts
@@ -1,18 +1,15 @@
 import invariant from 'tiny-invariant';
 import { useCallback } from 'react';
+import { InjectedConnector } from '@web3-react/injected-connector';
 import { openWindow } from '@lido-sdk/helpers';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import {
-  hasInjected,
-  isFirefox,
-  isMobileOrTablet,
-  isTallyProvider,
-} from '../helpers';
+import { hasInjected, isFirefox, isTallyProvider } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 
 type Connector = {
-  connect?: () => Promise<void>;
+  connect: () => Promise<void>;
+  connector: InjectedConnector;
 };
 
 const chromeAppLink =
@@ -43,9 +40,8 @@ export const useConnectorTally = (): Connector => {
     }
   }, [activate, disconnect, suggestApp, injected]);
 
-  const available = !isMobileOrTablet;
-
   return {
-    connect: available ? connect : undefined,
+    connect,
+    connector: injected,
   };
 };

--- a/packages/web3-react/src/hooks/useConnectorTrust.ts
+++ b/packages/web3-react/src/hooks/useConnectorTrust.ts
@@ -2,13 +2,15 @@ import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
 import { openWindow } from '@lido-sdk/helpers';
+import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isIOS, isMobileOrTablet } from '../helpers';
+import { hasInjected } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 
 type Connector = {
-  connect?: () => Promise<void>;
+  connect: () => Promise<void>;
+  connector: InjectedConnector;
 };
 
 const TRUST_URL = 'https://link.trustwallet.com/open_url?url=';
@@ -38,9 +40,8 @@ export const useConnectorTrust = (): Connector => {
     }
   }, [activate, disconnect, openInWallet, injected]);
 
-  const available = isMobileOrTablet && !isIOS;
-
   return {
-    connect: available ? connect : undefined,
+    connect,
+    connector: injected,
   };
 };

--- a/packages/web3-react/src/hooks/useConnectorWalletConnect.ts
+++ b/packages/web3-react/src/hooks/useConnectorWalletConnect.ts
@@ -2,9 +2,11 @@ import { useCallback } from 'react';
 import { useConnectors } from './useConnectors';
 import { useForceDisconnect } from './useDisconnect';
 import { useWeb3 } from './useWeb3';
+import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 
 type Connector = {
   connect: () => Promise<void>;
+  connector: WalletConnectConnector;
 };
 
 export const useConnectorWalletConnect = (): Connector => {
@@ -17,5 +19,5 @@ export const useConnectorWalletConnect = (): Connector => {
     activate(walletconnect);
   }, [activate, disconnect, walletconnect]);
 
-  return { connect };
+  return { connect, connector: walletconnect };
 };

--- a/packages/web3-react/test/hooks/useConnectorImToken.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorImToken.test.ts
@@ -42,14 +42,6 @@ describe('useConnectorImToken', () => {
     expect(connect).toBeDefined;
   });
 
-  test('should not return connect if it’s not mobile', async () => {
-    mockIsMobileOrTablet.mockReturnValue(false);
-    const { result } = renderHook(() => useConnectorImToken());
-    const { connect } = result.current;
-
-    expect(connect).toBeUndefined();
-  });
-
   test('should connect if ethereum if presented', async () => {
     const mockActivate = jest.fn(async () => true);
     const injected = {};

--- a/packages/web3-react/test/hooks/useConnectorLedger.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorLedger.test.ts
@@ -26,17 +26,4 @@ describe('useConnectorLedger', () => {
     expect(mockActivate).toHaveBeenCalledWith(ledger);
     expect(mockActivate).toHaveBeenCalledTimes(1);
   });
-
-  test('should not return connect if HID is not supported', async () => {
-    const mockActivate = jest.fn(async () => true);
-    const ledger = { isSupported: () => false };
-
-    mockUseWeb3.mockReturnValue({ activate: mockActivate } as any);
-    mockUseConnectors.mockReturnValue({ ledger } as any);
-
-    const { result } = renderHook(() => useConnectorLedger());
-    const { connect } = result.current;
-
-    expect(connect).toBeUndefined();
-  });
 });

--- a/packages/web3-react/test/hooks/useConnectorTrust.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorTrust.test.ts
@@ -42,14 +42,6 @@ describe('useConnectorTrust', () => {
     expect(connect).toBeDefined;
   });
 
-  test('should not return connect if it’s not mobile', async () => {
-    mockIsMobileOrTablet.mockReturnValue(false);
-    const { result } = renderHook(() => useConnectorTrust());
-    const { connect } = result.current;
-
-    expect(connect).toBeUndefined();
-  });
-
   test('should connect if ethereum if presented', async () => {
     const mockActivate = jest.fn(async () => true);
     const injected = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,7 +2669,7 @@ __metadata:
     "@web3-react/walletlink-connector": 6.2.5
     tiny-invariant: ^1.1.0
     tiny-warning: ^1.0.3
-    ua-parser-js: ^0.7.28
+    ua-parser-js: 1.0.2
     web3-ledgerhq-connector: ^1.2.2
     web3-ledgerhq-frame-connector: ^1.0.1
   peerDependencies:
@@ -14206,10 +14206,10 @@ typescript@^4.4.3:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^0.7.28":
-  version: 0.7.28
-  resolution: "ua-parser-js@npm:0.7.28"
-  checksum: a7da4ad54527211e878ee016c2ef64efad5c2f5a31277d36c9da93b4c89ecaa64f391ad4cf158ada76a9ad8e53004a950705ff1c2f27a52ca8bfb3f1381c39ff
+"ua-parser-js@npm:1.0.2":
+  version: 1.0.2
+  resolution: "ua-parser-js@npm:1.0.2"
+  checksum: ff7f6d79a9c1a38aa85a0e751040fc7e17a0b621bda876838d14ebe55aca4e50e68da0350f181e58801c2d8a35e7db4e12473776e558910c4b7cabcec96aa3bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Update `ua-parser-js` to 1.0.2, the same version as `lido-ui-blocks` package uses.
- The `connect` function returned by a connector hook must not be `undefined`.
- A connector hook should also return a connector.
- Remove the `ledger.isSupported` check because I want to move it to the `connect-wallet-modal` lib.