### PR TITLE
Feat(lido-js-sdk): add WalletConnectUri connector

### DIFF
--- a/packages/web3-react/src/constants/connectors.ts
+++ b/packages/web3-react/src/constants/connectors.ts
@@ -17,6 +17,7 @@ export enum PROVIDER_NAMES {
 export enum CONNECTOR_NAMES {
   GNOSIS = 'gnosis',
   WALLET_CONNECT = 'walletconnect',
+  WALLET_CONNECT_URI = 'WalletConnectUri',
   WALLET_LINK = 'walletlink',
   COINBASE = 'coinbase',
   INJECTED = 'injected',

--- a/packages/web3-react/src/context/connectors.tsx
+++ b/packages/web3-react/src/context/connectors.tsx
@@ -1,4 +1,4 @@
-import { createContext, memo, FC, useMemo } from 'react';
+import { createContext, FC, memo, useMemo } from 'react';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 import { WalletLinkConnector } from '@web3-react/walletlink-connector';
@@ -21,6 +21,7 @@ export interface ConnectorsContextProps {
 export type ConnectorsContextValue = {
   injected: InjectedConnector;
   walletconnect: WalletConnectConnector;
+  WalletConnectUri: WalletConnectConnector;
   walletlink: WalletLinkConnector;
   coinbase: WalletLinkConnector;
   ledgerlive: LedgerHQFrameConnector;
@@ -85,6 +86,13 @@ const ProviderConnectors: FC<ConnectorsContextProps> = (props) => {
           ],
           desktopLinks: [],
         },
+      }),
+
+      [CONNECTOR_NAMES.WALLET_CONNECT_URI]: new WalletConnectConnector({
+        storageId: 'lido-walletconnect',
+        supportedChainIds,
+        rpc: walletConnectRPC,
+        qrcode: false,
       }),
 
       [CONNECTOR_NAMES.GNOSIS]: (() => {

--- a/packages/web3-react/src/hooks/index.ts
+++ b/packages/web3-react/src/hooks/index.ts
@@ -10,6 +10,7 @@ export * from './useConnectors';
 export * from './useConnectorStorage';
 export * from './useConnectorTrust';
 export * from './useConnectorWalletConnect';
+export * from './useConnectorWalletConnectUri';
 export * from './useConnectorTally';
 export * from './useDisconnect';
 export * from './useSupportedChains';

--- a/packages/web3-react/src/hooks/useConnectorWalletConnectUri.ts
+++ b/packages/web3-react/src/hooks/useConnectorWalletConnectUri.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { useConnectors } from './useConnectors';
+import { useForceDisconnect } from './useDisconnect';
+import { useWeb3 } from './useWeb3';
+import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
+
+type Connector = {
+  connect: () => Promise<void>;
+  connector: WalletConnectConnector;
+};
+
+export const useConnectorWalletConnectUri = (): Connector => {
+  const { WalletConnectUri: connector } = useConnectors();
+
+  const { activate } = useWeb3();
+  const { disconnect } = useForceDisconnect();
+
+  const connect = useCallback(async () => {
+    await disconnect();
+    activate(connector);
+  }, [activate, disconnect, connector]);
+
+  return { connect, connector };
+};


### PR DESCRIPTION
This PR adds a WalletConnect connector which doesn't show the QR code modal and emits a special uri string instead.
It is required for the Ambire Wallet integration.