### PR TITLE
fix(lido-js-sdk): Tally firefox link, imToken deeplink

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorImToken.ts
+++ b/packages/web3-react/src/hooks/useConnectorImToken.ts
@@ -13,7 +13,7 @@ type Connector = {
   connector: InjectedConnector;
 };
 
-const IM_TOKEN_URL = 'imtokenv2://navigate?screen=DappView&url=';
+const IM_TOKEN_URL = 'imtokenv2://navigate/DappView?url=';
 
 export const useConnectorImToken = (): Connector => {
   const { injected } = useConnectors();

--- a/packages/web3-react/src/hooks/useConnectorTally.ts
+++ b/packages/web3-react/src/hooks/useConnectorTally.ts
@@ -14,7 +14,7 @@ type Connector = {
 
 const chromeAppLink =
   'https://chrome.google.com/webstore/detail/tally-ho/eajafomhmkipbjmfmhebemolkcicgfmd';
-const firefoxAppLink = 'https://addons.mozilla.org/en-US/firefox/addon/tally/';
+const firefoxAppLink = 'https://tally.cash/community-edition/';
 
 export const useConnectorTally = (): Connector => {
   const { injected } = useConnectors();


### PR DESCRIPTION
Tally devs removed their extension from FF extensions store.
We decided to redirect to https://tally.cash/community-edition/, where a user can download FF extension as .xpi file.

Another minor update: use new deeplink format for imToken, according to their docs: https://imtoken.gitbook.io/developers/products/deep-linking 