### PR TITLE
Fix(web3-react): check brave wallet on metamask connection

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorMetamask.ts
+++ b/packages/web3-react/src/hooks/useConnectorMetamask.ts
@@ -4,7 +4,11 @@ import { useCallback } from 'react';
 import { openWindow } from '@lido-sdk/helpers';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected } from '../helpers';
+import {
+  hasInjected,
+  isMetamaskProvider,
+  isBraveWalletProvider,
+} from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { InjectedConnector } from '@web3-react/injected-connector';
 
@@ -33,7 +37,11 @@ export const useConnectorMetamask = (): Connector => {
   const connect = useCallback(async () => {
     invariant(injected, 'Connector is required');
 
-    if (hasInjected()) {
+    // Brave Wallet mimics MetaMask.
+    // If a user has the Brave Browser without the MetaMask extension we want
+    // to redirect the user to the MetaMask website.
+    // TODO: refactor
+    if (hasInjected() && isMetamaskProvider() && !isBraveWalletProvider()) {
       await disconnect();
       activate(injected);
     } else {

--- a/packages/web3-react/test/hooks/useConnectorMetamask.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorMetamask.test.ts
@@ -26,11 +26,12 @@ beforeEach(() => {
 });
 
 describe('useConnectorMetamask', () => {
-  test('should connect if ethereum if presented', async () => {
+  test('should connect if ethereum and MetaMask are presented', async () => {
     const mockActivate = jest.fn(async () => true);
     const injected = {};
 
     window.ethereum = {};
+    window.ethereum.isMetaMask = true;
     mockUseWeb3.mockReturnValue({ activate: mockActivate } as any);
     mockUseConnectors.mockReturnValue({ injected } as any);
 


### PR DESCRIPTION
Brave Wallet mimics MetaMask by setting `isMetaMask = true`.
In the case when a user has the Brave Browser but MetaMask is not installed, and the user clicks "MetaMask" button, we want the user to be redirected to the MetaMask website.
Therefore, we need an additional check for `!isBraveWalletProvider`.
Otherwise, the user will be connected to the Brave Wallet instead of being redirected to the MetaMask website.