### PR TITLE
Add new WalletConnect connector without mobile links

### DIFF
--- a/packages/web3-react/src/constants/connectors.ts
+++ b/packages/web3-react/src/constants/connectors.ts
@@ -19,6 +19,7 @@ export enum CONNECTOR_NAMES {
   GNOSIS = 'gnosis',
   WALLET_CONNECT = 'walletconnect',
   WALLET_CONNECT_URI = 'WalletConnectUri',
+  WALLET_CONNECT_NOLINKS = 'WalletConnectNoLinks',
   WALLET_LINK = 'walletlink',
   COINBASE = 'coinbase',
   INJECTED = 'injected',

--- a/packages/web3-react/src/context/connectors.tsx
+++ b/packages/web3-react/src/context/connectors.tsx
@@ -22,6 +22,7 @@ export type ConnectorsContextValue = {
   injected: InjectedConnector;
   walletconnect: WalletConnectConnector;
   WalletConnectUri: WalletConnectConnector;
+  WalletConnectNoLinks: WalletConnectConnector;
   walletlink: WalletLinkConnector;
   coinbase: WalletLinkConnector;
   ledgerlive: LedgerHQFrameConnector;
@@ -88,8 +89,18 @@ const ProviderConnectors: FC<ConnectorsContextProps> = (props) => {
         },
       }),
 
+      [CONNECTOR_NAMES.WALLET_CONNECT_NOLINKS]: new WalletConnectConnector({
+        storageId: 'lido-walletconnect-nolinks',
+        supportedChainIds,
+        rpc: walletConnectRPC,
+        qrcodeModalOptions: {
+          mobileLinks: [],
+          desktopLinks: [],
+        },
+      }),
+
       [CONNECTOR_NAMES.WALLET_CONNECT_URI]: new WalletConnectConnector({
-        storageId: 'lido-walletconnect',
+        storageId: 'lido-walletconnect-uri',
         supportedChainIds,
         rpc: walletConnectRPC,
         qrcode: false,

--- a/packages/web3-react/src/hooks/index.ts
+++ b/packages/web3-react/src/hooks/index.ts
@@ -11,6 +11,7 @@ export * from './useConnectorStorage';
 export * from './useConnectorTrust';
 export * from './useConnectorWalletConnect';
 export * from './useConnectorWalletConnectUri';
+export * from './useConnectorWalletConnectNoLinks';
 export * from './useConnectorTally';
 export * from './useConnectorBraveWallet';
 export * from './useDisconnect';

--- a/packages/web3-react/src/hooks/useConnectorWalletConnectNoLinks.ts
+++ b/packages/web3-react/src/hooks/useConnectorWalletConnectNoLinks.ts
@@ -9,8 +9,8 @@ type Connector = {
   connector: WalletConnectConnector;
 };
 
-export const useConnectorWalletConnectUri = (): Connector => {
-  const { WalletConnectUri: connector } = useConnectors();
+export const useConnectorWalletConnectNoLinks = (): Connector => {
+  const { WalletConnectNoLinks: connector } = useConnectors();
   const { activate } = useWeb3();
   const { disconnect } = useForceDisconnect();
 


### PR DESCRIPTION
This PR clones regular `WALLET_CONNECT` connector, but configures it to not have mobile links tab.

<img width=300 src="https://user-images.githubusercontent.com/1245209/180199373-f4a46a1c-6f19-4309-9207-ecc511690c90.png">
