### PR TITLE
Fix(web3-react): use the same storageId for all WC connectors

### DIFF
--- a/packages/web3-react/src/context/connectors.tsx
+++ b/packages/web3-react/src/context/connectors.tsx
@@ -90,7 +90,7 @@ const ProviderConnectors: FC<ConnectorsContextProps> = (props) => {
       }),
 
       [CONNECTOR_NAMES.WALLET_CONNECT_NOLINKS]: new WalletConnectConnector({
-        storageId: 'lido-walletconnect-nolinks',
+        storageId: 'lido-walletconnect',
         supportedChainIds,
         rpc: walletConnectRPC,
         qrcodeModalOptions: {
@@ -100,7 +100,7 @@ const ProviderConnectors: FC<ConnectorsContextProps> = (props) => {
       }),
 
       [CONNECTOR_NAMES.WALLET_CONNECT_URI]: new WalletConnectConnector({
-        storageId: 'lido-walletconnect-uri',
+        storageId: 'lido-walletconnect',
         supportedChainIds,
         rpc: walletConnectRPC,
         qrcode: false,


### PR DESCRIPTION
Turned out that different storageId keys for WalletConnect connectors are causing issues with our autoconnect mechanism. For now, it should be `lido-walletconnect`. And it will be nice to refactor it sometime later.