### PR TITLE
Add Opera Crypto Wallet

### DIFF
--- a/packages/web3-react/src/constants/connectors.ts
+++ b/packages/web3-react/src/constants/connectors.ts
@@ -14,6 +14,7 @@ export enum PROVIDER_NAMES {
   TALLY = 'Tally',
   BRAVE = 'Brave Wallet',
   EXODUS = 'Exodus',
+  OPERA = 'Opera Crypto Wallet',
 }
 
 export enum CONNECTOR_NAMES {
@@ -26,5 +27,4 @@ export enum CONNECTOR_NAMES {
   INJECTED = 'injected',
   LEDGER_HQ_LIVE = 'ledgerlive',
   LEDGER = 'ledger',
-  EXODUS = 'exodus',
 }

--- a/packages/web3-react/src/helpers/providerDetectors.ts
+++ b/packages/web3-react/src/helpers/providerDetectors.ts
@@ -13,6 +13,7 @@ declare global {
       isTally?: boolean;
       isBraveWallet?: boolean;
       isExodus?: boolean;
+      isOpera?: boolean;
     };
   }
 }
@@ -88,6 +89,14 @@ export const isTallyProvider = (): boolean => {
 export const isBraveWalletProvider = (): boolean => {
   try {
     return !!window.ethereum?.isBraveWallet;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const isOperaWalletProvider = (): boolean => {
+  try {
+    return !!window.ethereum?.isOpera;
   } catch (error) {
     return false;
   }

--- a/packages/web3-react/src/hooks/index.ts
+++ b/packages/web3-react/src/hooks/index.ts
@@ -14,6 +14,7 @@ export * from './useConnectorWalletConnectUri';
 export * from './useConnectorWalletConnectNoLinks';
 export * from './useConnectorTally';
 export * from './useConnectorBraveWallet';
+export * from './useConnectorOperaWallet';
 export * from './useConnectorExodus';
 export * from './useDisconnect';
 export * from './useSupportedChains';

--- a/packages/web3-react/src/hooks/useConnectorInfo.ts
+++ b/packages/web3-react/src/hooks/useConnectorInfo.ts
@@ -8,16 +8,17 @@ import { useWeb3 } from './useWeb3';
 import { CONNECTOR_NAMES, PROVIDER_NAMES } from '../constants';
 import { Connector } from '../context';
 import {
-  isDappBrowserProvider,
-  isImTokenProvider,
-  isMetamaskProvider,
-  isCoin98Provider,
-  isTrustProvider,
-  isMathWalletProvider,
-  isCoinbaseProvider,
-  isTallyProvider,
   isBraveWalletProvider,
+  isCoin98Provider,
+  isCoinbaseProvider,
+  isDappBrowserProvider,
   isExodusProvider,
+  isImTokenProvider,
+  isMathWalletProvider,
+  isMetamaskProvider,
+  isOperaWalletProvider,
+  isTallyProvider,
+  isTrustProvider,
 } from '../helpers';
 
 type ConnectorInfo = {
@@ -59,6 +60,7 @@ export const useConnectorInfo = (): ConnectorInfo => {
   const isTrust = isInjected && isTrustProvider();
   const isTally = isInjected && isTallyProvider();
   const isBraveWallet = isInjected && isBraveWalletProvider();
+  const isOperaWallet = isInjected && isOperaWalletProvider();
   const isExodus = isInjected && isExodusProvider();
 
   const providerName = (() => {
@@ -78,6 +80,7 @@ export const useConnectorInfo = (): ConnectorInfo => {
     if (isMathWallet) return PROVIDER_NAMES.MATH_WALLET;
     if (isCoin98) return PROVIDER_NAMES.COIN98;
     if (isCoinbase) return PROVIDER_NAMES.COINBASE;
+    if (isOperaWallet) return PROVIDER_NAMES.OPERA;
     if (isBraveWallet) return PROVIDER_NAMES.BRAVE;
     // Metamask should be last in this list because almost all EIP-1193 wallets
     // are trying to mimic Metamask by setting isMetamask = true

--- a/packages/web3-react/src/hooks/useConnectorOperaWallet.ts
+++ b/packages/web3-react/src/hooks/useConnectorOperaWallet.ts
@@ -1,0 +1,43 @@
+import invariant from 'tiny-invariant';
+import warning from 'tiny-warning';
+import { useCallback } from 'react';
+import { openWindow } from '@lido-sdk/helpers';
+import { useConnectors } from './useConnectors';
+import { useWeb3 } from './useWeb3';
+import { hasInjected, isOperaWalletProvider } from '../helpers';
+import { useForceDisconnect } from './useDisconnect';
+import { InjectedConnector } from '@web3-react/injected-connector';
+
+type Connector = {
+  connect: () => Promise<void>;
+  connector: InjectedConnector;
+};
+
+const OPERA_URL = 'https://www.opera.com/crypto/next';
+
+export const useConnectorOperaWallet = (): Connector => {
+  const { injected } = useConnectors();
+  const { activate } = useWeb3();
+  const { disconnect } = useForceDisconnect();
+
+  const suggestApp = useCallback(() => {
+    try {
+      openWindow(OPERA_URL);
+    } catch (error) {
+      warning(false, 'Failed to open the link');
+    }
+  }, []);
+
+  const connect = useCallback(async () => {
+    invariant(injected, 'Connector is required');
+
+    if (hasInjected() && isOperaWalletProvider()) {
+      await disconnect();
+      activate(injected);
+    } else {
+      suggestApp();
+    }
+  }, [activate, disconnect, suggestApp, injected]);
+
+  return { connect, connector: injected };
+};

--- a/packages/web3-react/test/hooks/useConnectorOpera.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorOpera.test.ts
@@ -1,0 +1,60 @@
+jest.mock('@lido-sdk/helpers');
+jest.mock('../../src/hooks/useWeb3');
+jest.mock('../../src/hooks/useConnectors');
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { openWindow } from '@lido-sdk/helpers';
+import { useConnectorOperaWallet, useWeb3, useConnectors } from '../../src';
+
+const mockUseWeb3 = useWeb3 as jest.MockedFunction<typeof useWeb3>;
+const mockUseConnectors = useConnectors as jest.MockedFunction<
+  typeof useConnectors
+>;
+const mockOpenWindow = openWindow as jest.MockedFunction<typeof openWindow>;
+
+beforeEach(() => {
+  delete window.ethereum;
+  mockUseWeb3.mockReturnValue({} as any);
+  mockUseConnectors.mockReturnValue({ injected: {} } as any);
+  mockOpenWindow.mockReset();
+});
+
+describe('useConnectorOperaWallet', () => {
+  test('should connect if ethereum and Opera are presented', async () => {
+    const mockActivate = jest.fn(async () => true);
+    const injected = {};
+
+    window.ethereum = {};
+    window.ethereum.isOpera = true;
+    mockUseWeb3.mockReturnValue({ activate: mockActivate } as any);
+    mockUseConnectors.mockReturnValue({ injected } as any);
+
+    const { result } = renderHook(() => useConnectorOperaWallet());
+    const { connect } = result.current;
+
+    await act(() => connect());
+    expect(mockActivate).toHaveBeenCalledWith(injected);
+    expect(mockActivate).toHaveBeenCalledTimes(1);
+  });
+
+  test('should open window if ethereum is not presented', async () => {
+    const { result } = renderHook(() => useConnectorOperaWallet());
+    const { connect } = result.current;
+
+    window.ethereum = undefined;
+
+    await act(() => connect());
+    expect(mockOpenWindow).toHaveBeenCalledTimes(1);
+  });
+
+  test('should open window if Opera is not presented', async () => {
+    const { result } = renderHook(() => useConnectorOperaWallet());
+    const { connect } = result.current;
+
+    window.ethereum = {};
+    window.ethereum.isOpera = undefined;
+
+    await act(() => connect());
+    expect(mockOpenWindow).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This PR adds a connector for the [Opera Crypto Browser Wallet](https://www.opera.com/crypto/next) and other required code.
Some docs: https://help.opera.com/en/crypto/opera-wallet-integration-guide/