### PR TITLE
Wallets fixes set

### DIFF
--- a/packages/web3-react/src/helpers/providerDetectors.ts
+++ b/packages/web3-react/src/helpers/providerDetectors.ts
@@ -38,7 +38,7 @@ export const isMetamaskProvider = (): boolean => {
 
 export const isCoin98Provider = (): boolean => {
   try {
-    return !!window.coin98 || !!window.ethereum?.isCoin98;
+    return !!window.ethereum?.isCoin98;
   } catch (error) {
     return false;
   }

--- a/packages/web3-react/src/helpers/providerDetectors.ts
+++ b/packages/web3-react/src/helpers/providerDetectors.ts
@@ -15,6 +15,7 @@ declare global {
       isExodus?: boolean;
       isOpera?: boolean;
       isGamestop?: boolean;
+      providers?: { isCoinbaseWallet?: boolean }[];
     };
   }
 }
@@ -73,7 +74,17 @@ export const isDappBrowserProvider = (): boolean => {
 
 export const isCoinbaseProvider = (): boolean => {
   try {
-    return !!window.ethereum?.isCoinbaseWallet;
+    if (window.ethereum) {
+      const { isCoinbaseWallet, providers } = window.ethereum;
+      if (isCoinbaseWallet !== undefined) return isCoinbaseWallet;
+
+      // Handle the case when Coinbase knows that other wallets extensions
+      // are installed too, so it changes its behaviour and adds `providers`.
+      if (providers?.length) {
+        return providers.some((provider) => provider.isCoinbaseWallet);
+      }
+    }
+    return false;
   } catch (error) {
     return false;
   }

--- a/packages/web3-react/src/hooks/useConnectorInfo.ts
+++ b/packages/web3-react/src/hooks/useConnectorInfo.ts
@@ -78,10 +78,10 @@ export const useConnectorInfo = (): ConnectorInfo => {
     // Most "aggressive" wallet, which overrides other wallets, goes first.
     if (isTally) return PROVIDER_NAMES.TALLY;
     if (isExodus) return PROVIDER_NAMES.EXODUS;
+    if (isGamestop) return PROVIDER_NAMES.GAMESTOP;
     if (isMathWallet) return PROVIDER_NAMES.MATH_WALLET;
     if (isCoin98) return PROVIDER_NAMES.COIN98;
     if (isCoinbase) return PROVIDER_NAMES.COINBASE;
-    if (isGamestop) return PROVIDER_NAMES.GAMESTOP;
     if (isOperaWallet) return PROVIDER_NAMES.OPERA;
     if (isBraveWallet) return PROVIDER_NAMES.BRAVE;
     // Metamask should be last in this list because almost all EIP-1193 wallets

--- a/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
@@ -27,7 +27,7 @@ describe('useConnectorCoin98', () => {
     const injected = {};
 
     window.ethereum = {};
-    window.coin98 = true;
+    window.ethereum.isCoin98 = true;
     mockUseWeb3.mockReturnValue({ activate: mockActivate } as any);
     mockUseConnectors.mockReturnValue({ injected } as any);
 


### PR DESCRIPTION
This is a set of various wallets-related fixes:
- Fix detecting Coinbase wallet in the case when it is installed along with some other wallet (at least MetaMask). Probably fixes this issue https://github.com/lidofinance/lido-js-sdk/issues/66
- Makes Coin98 detection more strict
- Lifts Gamestop position in `providerName` order, which is more accurate