### PR TITLE
fix(web3-react): await activate for WC

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorWalletConnect.ts
+++ b/packages/web3-react/src/hooks/useConnectorWalletConnect.ts
@@ -16,7 +16,7 @@ export const useConnectorWalletConnect = (): ConnectorHookResult => {
 
   const connect = useCallback(async () => {
     await disconnect();
-    activate(walletconnect);
+    await activate(walletconnect);
   }, [activate, disconnect, walletconnect]);
 
   return { connect, connector: walletconnect };

--- a/packages/web3-react/src/hooks/useConnectorWalletConnectNoLinks.ts
+++ b/packages/web3-react/src/hooks/useConnectorWalletConnectNoLinks.ts
@@ -16,7 +16,7 @@ export const useConnectorWalletConnectNoLinks = (): ConnectorHookResult => {
 
   const connect = useCallback(async () => {
     await disconnect();
-    activate(connector);
+    await activate(connector);
   }, [activate, disconnect, connector]);
 
   return { connect, connector };

--- a/packages/web3-react/src/hooks/useConnectorWalletConnectUri.ts
+++ b/packages/web3-react/src/hooks/useConnectorWalletConnectUri.ts
@@ -16,7 +16,7 @@ export const useConnectorWalletConnectUri = (): ConnectorHookResult => {
 
   const connect = useCallback(async () => {
     await disconnect();
-    activate(connector);
+    await activate(connector);
   }, [activate, disconnect, connector]);
 
   return { connect, connector };


### PR DESCRIPTION
`activate` is an async function, returns a Promise, and it should be awaited for WC connectors (at least).
This is required for the `connect` function to be properly awaited, which is required now for ZenGo wallet deeplinks integration.