### PR TITLE
fix(web3-react): add xdefi and other wallets detectors to useConnectorInfo hook

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorInfo.ts
+++ b/packages/web3-react/src/hooks/useConnectorInfo.ts
@@ -20,22 +20,31 @@ import {
   isOperaWalletProvider,
   isTallyProvider,
   isTrustProvider,
+  isXdefiProvider,
 } from '../helpers';
 
 type ConnectorInfo = {
-  isDappBrowser: boolean;
-  isInjected: boolean;
-  isImToken: boolean;
-  isTrust: boolean;
-  isMetamask: boolean;
-  isCoin98: boolean;
+  providerName?: string;
+  connectorName?: Connector;
   isGnosis: boolean;
   isLedger: boolean;
   isLedgerLive: boolean;
   isWalletConnect: boolean;
+  isWalletLink: boolean;
   isCoinbase: boolean;
-  providerName?: string;
-  connectorName?: Connector;
+  isMetamask: boolean;
+  isCoin98: boolean;
+  isMathWallet: boolean;
+  isImToken: boolean;
+  isTrust: boolean;
+  isTally: boolean;
+  isBraveWallet: boolean;
+  isOperaWallet: boolean;
+  isExodus: boolean;
+  isGamestop: boolean;
+  isXdefi: boolean;
+  isDappBrowser: boolean;
+  isInjected: boolean;
 };
 
 export const useConnectorInfo = (): ConnectorInfo => {
@@ -64,6 +73,7 @@ export const useConnectorInfo = (): ConnectorInfo => {
   const isOperaWallet = isInjected && isOperaWalletProvider();
   const isExodus = isInjected && isExodusProvider();
   const isGamestop = isInjected && isGamestopProvider();
+  const isXdefi = isInjected && isXdefiProvider();
 
   const providerName = (() => {
     if (isGnosis) return PROVIDER_NAMES.GNOSIS;
@@ -78,6 +88,7 @@ export const useConnectorInfo = (): ConnectorInfo => {
     // Most "aggressive" wallet, which overrides other wallets, goes first.
     if (isTally) return PROVIDER_NAMES.TALLY;
     if (isExodus) return PROVIDER_NAMES.EXODUS;
+    if (isXdefi) return PROVIDER_NAMES.XDEFI;
     if (isGamestop) return PROVIDER_NAMES.GAMESTOP;
     if (isMathWallet) return PROVIDER_NAMES.MATH_WALLET;
     if (isCoin98) return PROVIDER_NAMES.COIN98;
@@ -115,16 +126,25 @@ export const useConnectorInfo = (): ConnectorInfo => {
     connectorName,
     providerName,
 
-    isCoinbase,
     isGnosis,
     isLedger,
     isLedgerLive,
     isWalletConnect,
 
-    isImToken,
+    isWalletLink,
+    isCoinbase,
+
     isMetamask,
     isCoin98,
+    isMathWallet,
+    isImToken,
     isTrust,
+    isTally,
+    isBraveWallet,
+    isOperaWallet,
+    isExodus,
+    isGamestop,
+    isXdefi,
 
     isDappBrowser,
     isInjected,

--- a/packages/web3-react/test/hooks/useConnectorInfo.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorInfo.test.ts
@@ -84,7 +84,7 @@ describe('useConnectorInfo', () => {
     expect(Object.values(rest).includes(true)).toBeFalsy();
   });
 
-  test('should detect metamask', async () => {
+  test('should detect MetaMask', async () => {
     mockConnector(InjectedConnector);
     window.ethereum = { isMetaMask: true };
 
@@ -94,6 +94,32 @@ describe('useConnectorInfo', () => {
 
     expect(isInjected).toBe(true);
     expect(isMetamask).toBe(true);
+    expect(Object.values(rest).includes(true)).toBeFalsy();
+  });
+
+  test('should detect Coin98', async () => {
+    mockConnector(InjectedConnector);
+    window.ethereum = { isCoin98: true };
+
+    const { result } = renderHook(() => useConnectorInfo());
+    const { connectorName, providerName, isInjected, isCoin98, ...rest } =
+      result.current;
+
+    expect(isInjected).toBe(true);
+    expect(isCoin98).toBe(true);
+    expect(Object.values(rest).includes(true)).toBeFalsy();
+  });
+
+  test('should detect MathWallet', async () => {
+    mockConnector(InjectedConnector);
+    window.ethereum = { isMathWallet: true };
+
+    const { result } = renderHook(() => useConnectorInfo());
+    const { connectorName, providerName, isInjected, isMathWallet, ...rest } =
+      result.current;
+
+    expect(isInjected).toBe(true);
+    expect(isMathWallet).toBe(true);
     expect(Object.values(rest).includes(true)).toBeFalsy();
   });
 
@@ -120,6 +146,85 @@ describe('useConnectorInfo', () => {
 
     expect(isInjected).toBe(true);
     expect(isTrust).toBe(true);
+    expect(Object.values(rest).includes(true)).toBeFalsy();
+  });
+
+  test('should detect Tally', async () => {
+    mockConnector(InjectedConnector);
+    window.ethereum = { isTally: true };
+
+    const { result } = renderHook(() => useConnectorInfo());
+    const { connectorName, providerName, isInjected, isTally, ...rest } =
+      result.current;
+
+    expect(isInjected).toBe(true);
+    expect(isTally).toBe(true);
+    expect(Object.values(rest).includes(true)).toBeFalsy();
+  });
+
+  test('should detect Brave', async () => {
+    mockConnector(InjectedConnector);
+    window.ethereum = { isBraveWallet: true };
+
+    const { result } = renderHook(() => useConnectorInfo());
+    const { connectorName, providerName, isInjected, isBraveWallet, ...rest } =
+      result.current;
+
+    expect(isInjected).toBe(true);
+    expect(isBraveWallet).toBe(true);
+    expect(Object.values(rest).includes(true)).toBeFalsy();
+  });
+
+  test('should detect Opera', async () => {
+    mockConnector(InjectedConnector);
+    window.ethereum = { isOpera: true };
+
+    const { result } = renderHook(() => useConnectorInfo());
+    const { connectorName, providerName, isInjected, isOperaWallet, ...rest } =
+      result.current;
+
+    expect(isInjected).toBe(true);
+    expect(isOperaWallet).toBe(true);
+    expect(Object.values(rest).includes(true)).toBeFalsy();
+  });
+
+  test('should detect Exodus', async () => {
+    mockConnector(InjectedConnector);
+    window.ethereum = { isExodus: true };
+
+    const { result } = renderHook(() => useConnectorInfo());
+    const { connectorName, providerName, isInjected, isExodus, ...rest } =
+      result.current;
+
+    expect(isInjected).toBe(true);
+    expect(isExodus).toBe(true);
+    expect(Object.values(rest).includes(true)).toBeFalsy();
+  });
+
+  test('should detect Gamestop', async () => {
+    mockConnector(InjectedConnector);
+    window.ethereum = { isGamestop: true };
+
+    const { result } = renderHook(() => useConnectorInfo());
+    const { connectorName, providerName, isInjected, isGamestop, ...rest } =
+      result.current;
+
+    expect(isInjected).toBe(true);
+    expect(isGamestop).toBe(true);
+    expect(Object.values(rest).includes(true)).toBeFalsy();
+  });
+
+  test('should detect XDEFI', async () => {
+    mockConnector(InjectedConnector);
+    window.ethereum = { isXDEFI: true };
+    window.xfi = {};
+
+    const { result } = renderHook(() => useConnectorInfo());
+    const { connectorName, providerName, isInjected, isXdefi, ...rest } =
+      result.current;
+
+    expect(isInjected).toBe(true);
+    expect(isXdefi).toBe(true);
     expect(Object.values(rest).includes(true)).toBeFalsy();
   });
 

--- a/packages/web3-react/test/hooks/useConnectorInfo.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorInfo.test.ts
@@ -68,7 +68,8 @@ describe('useConnectorInfo', () => {
     window.ethereum = { isCoinbaseWallet: true };
 
     const { result } = renderHook(() => useConnectorInfo());
-    const { connectorName, providerName, isCoinbase, ...rest } = result.current;
+    const { connectorName, providerName, isCoinbase, isWalletLink, ...rest } =
+      result.current;
 
     expect(isCoinbase).toBe(true);
     expect(Object.values(rest).includes(true)).toBeFalsy();


### PR DESCRIPTION
- Fixes an issue with a wrong detection of the connected XDEFI wallet
- Adds other wallets to ConnectorInfo, just for consistency