### PR TITLE
Fix(web3-react): add coin_id to trust wallet's deeplink url

### DIFF
--- a/packages/web3-react/src/hooks/useConnectorTrust.ts
+++ b/packages/web3-react/src/hooks/useConnectorTrust.ts
@@ -13,7 +13,7 @@ type ConnectorHookResult = {
   connector: InjectedConnector;
 };
 
-const WALLET_URL = 'https://link.trustwallet.com/open_url?url=';
+const WALLET_URL = 'https://link.trustwallet.com/open_url?coin_id=60&url=';
 
 export const useConnectorTrust = (): ConnectorHookResult => {
   const { injected } = useConnectors();


### PR DESCRIPTION
This PR adds coin_id param to Trust wallet's deeplink URL according to the docs: https://developer.trustwallet.com/deeplinking#dapp-browser
This should fix the reported issue with Trust deeplink on iOS.