### PR TITLE
Attempt to fix npm release: set "workspaces-update": false

### DIFF
--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -23,7 +23,8 @@
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "workspaces-update": false
   },
   "devDependencies": {
     "@types/jest": "^27.0.2"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -26,7 +26,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "workspaces-update": false
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.4.1",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -23,7 +23,8 @@
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "workspaces-update": false
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -23,7 +23,8 @@
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "workspaces-update": false
   },
   "devDependencies": {
     "@ethersproject/bignumber": "^5.4.2",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -23,7 +23,8 @@
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "workspaces-update": false
   },
   "devDependencies": {
     "@ethersproject/logger": "^5.4.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,8 @@
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "workspaces-update": false
   },
   "devDependencies": {
     "@ethersproject/bignumber": "^5.4.2",


### PR DESCRIPTION
The npm publish became broken after: https://github.com/lidofinance/lido-js-sdk/pull/119

Failed job: https://github.com/lidofinance/lido-js-sdk/actions/runs/10772387274/job/29869904950

The errors are:
```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

Related discussions:
- https://github.com/dhoulb/multi-semantic-release/issues/129
- https://github.com/semantic-release/npm/issues/495

As suggested, setting `"workspaces-update": false`, but via `publishConfig` instead of creating `.npmrc`
Docs: [workspaces-update](https://docs.npmjs.com/cli/v10/using-npm/config#workspaces-update)