### PR TITLE
Attempt to fix npm release №2: use .npmrc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,10 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
           echo "workspaces-update=false" >> .npmrc
-          echo "provenance=true" >> .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to NPM
         env:
-          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn multi-semantic-release --deps.bump=override --deps.release=patch --sequential-init

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,16 @@ jobs:
         run: yarn build
       - name: Run tests
         run: yarn test
+      - name: Setup .npmrc
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+          echo "workspaces-update=false" >> .npmrc
+          echo "provenance=true" >> .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to NPM
         env:
+          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn multi-semantic-release --deps.bump=override --deps.release=patch --sequential-init

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry = https://registry.npmjs.org/
+access = public
+workspaces-update = false

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-registry = https://registry.npmjs.org/
-access = public
-workspaces-update = false

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -21,6 +21,10 @@
     "lido-js-sdk",
     "lidofinance"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "devDependencies": {
     "@types/jest": "^27.0.2"
   },

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -21,11 +21,6 @@
     "lido-js-sdk",
     "lidofinance"
   ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public",
-    "workspaces-update": false
-  },
   "devDependencies": {
     "@types/jest": "^27.0.2"
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,11 +24,6 @@
   "scripts": {
     "typechain": "typechain --target=ethers-v5 --out-dir ./src/generated './src/abi/*.json'"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public",
-    "workspaces-update": false
-  },
   "devDependencies": {
     "@ethersproject/abi": "^5.4.1",
     "@ethersproject/abstract-signer": "^5.4.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -21,6 +21,10 @@
     "lido-js-sdk",
     "lidofinance"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "scripts": {
     "typechain": "typechain --target=ethers-v5 --out-dir ./src/generated './src/abi/*.json'"
   },

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -21,6 +21,10 @@
     "lido-js-sdk",
     "lidofinance"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "@types/node-fetch": "^2.5.12"

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -21,11 +21,6 @@
     "lido-js-sdk",
     "lidofinance"
   ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public",
-    "workspaces-update": false
-  },
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "@types/node-fetch": "^2.5.12"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -21,6 +21,10 @@
     "lido-js-sdk",
     "lidofinance"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "devDependencies": {
     "@ethersproject/bignumber": "^5.4.2",
     "@types/jest": "^27.0.2"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -21,11 +21,6 @@
     "lido-js-sdk",
     "lidofinance"
   ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public",
-    "workspaces-update": false
-  },
   "devDependencies": {
     "@ethersproject/bignumber": "^5.4.2",
     "@types/jest": "^27.0.2"

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -23,8 +23,7 @@
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public",
-    "workspaces-update": false
+    "access": "public"
   },
   "devDependencies": {
     "@ethersproject/logger": "^5.4.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,8 +23,7 @@
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public",
-    "workspaces-update": false
+    "access": "public"
   },
   "devDependencies": {
     "@ethersproject/bignumber": "^5.4.2",


### PR DESCRIPTION
https://github.com/lidofinance/lido-js-sdk/pull/121 didn't help: https://github.com/lidofinance/lido-js-sdk/actions/runs/10772693898

This PR is an attempt to fix npm publish by moving the config into .npmrc