### PR TITLE
chore: add CODEOWNERS entry for lido-si team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+* @lidofinance/lido-si
 .github @lidofinance/review-gh-workflows


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns all files to the `@lidofinance/lido-si` team for ownership.