### PR TITLE
feat: add Etherscan prefix for Hoodi chain

### DIFF
--- a/packages/helpers/src/etherscan.ts
+++ b/packages/helpers/src/etherscan.ts
@@ -19,6 +19,7 @@ export const ETHERSCAN_PREFIX_BY_NETWORK: {
   [CHAINS.Kovan]: 'kovan.',
   [CHAINS.Holesky]: 'holesky.',
   [CHAINS.Sepolia]: 'sepolia.',
+  [CHAINS.Hoodi]: 'hoodi.',
 };
 
 export const getEtherscanPrefix = (chainId: CHAINS): string => {


### PR DESCRIPTION


* [`packages/helpers/src/etherscan.ts`](diffhunk://#diff-5bba8f5045072db472fe6ddf11773fc5aa650860e7519df14ecfab4f953906eeR22): Added `Hoodi` network to the `ETHERSCAN_PREFIX_BY_NETWORK` object.